### PR TITLE
refined session affinity tests

### DIFF
--- a/tests/basic_service_test.go
+++ b/tests/basic_service_test.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	ctx   = context.Background()
-	delay = 10 * time.Second
+	delay = 5 * time.Second
 )
 
 // TestBasicService starts up the basic Kubernetes services available
@@ -284,6 +284,9 @@ func TestBasicService(t *testing.T) { // nolint
 					t.Error(err)
 				}
 
+				// required for wait complete ip rules creation
+				time.Sleep(delay)
+
 				// Set pod specification on entity model
 				pod.SetToPort(nodePort)
 				services = append(services, service.(*kubernetes.Service))
@@ -413,13 +416,13 @@ func TestExternalService(t *testing.T) {
 				t.Error(errors.New("no endpoint available"))
 			}
 
-			// required for wait complete rules creation
-			time.Sleep(delay)
-
 			nodePort, err := service.WaitForNodePort()
 			if err != nil {
 				t.Error(err)
 			}
+
+			// required for wait complete ip rules creation
+			time.Sleep(delay)
 
 			// Set pod specification on entity model
 			for _, pod := range pods {

--- a/tests/basic_service_test.go
+++ b/tests/basic_service_test.go
@@ -162,7 +162,8 @@ func TestBasicService(t *testing.T) { // nolint
 			// to validate if affiliation applies to same port
 			zap.L().Info(fmt.Sprintf("Testing connections to same ports, try multiple times to affirm the affiliation, should use same from/to peers: %v", fromToPeer))
 			zap.L().Debug(fmt.Sprintf("Session affinity peers: %v", fromToPeer))
-			for i := 0; i < 3; i++ {
+			const connectTimes = 3
+			for i := 0; i < connectTimes; i++ {
 				zap.L().Info("Connection via port 80")
 				reachabilityPort80 := matrix.NewReachability(pods, false)
 				for from, to := range fromToPeer {


### PR DESCRIPTION
    - to separate testing with same ports(80), and multiple ports(80, 81)
    - increased the connection times to 3 for affiliation affirmation.
