### PR TITLE
added tooling to get summary report from various CIs.

### DIFF
--- a/.github/workflows/antrea-proxy.yaml
+++ b/.github/workflows/antrea-proxy.yaml
@@ -1,4 +1,4 @@
-name: GH-Antrea-Proxy-1.4
+name: Antrea-Proxy-1.4
 on:
   push:
     branches:

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ sonobuoy-retrieve: ## Retrieve results from sonobuoy plugin
 clean: ## Clean up sonobuoy results and output binary
 	rm -rf results *_sonobuoy_* svc-test
 
+report:
+	go run ./cmd/report/main.go
+
 ##@ Verify
 
 .PHONY: verify verify-golangci-lint verify-go-mod

--- a/cmd/report/main.go
+++ b/cmd/report/main.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/k8sbykeshed/k8s-service-validator/tools"
+	"github.com/savaki/jq"
+	"go.uber.org/zap"
+)
+
+type Workflow struct {
+	name               string
+	status             string
+	id                 string
+	lastRunID          string
+	lastJobID          string
+	lastJobCompletedAt string
+	passedTests        map[string]bool
+	failedTests        map[string]bool
+}
+
+var wfmap map[string]*Workflow
+
+const (
+	cmd          = "/usr/local/bin/gh"
+	keyPassInLog = "PASS tests"
+	keyFailInLog = "FAIL: tests"
+)
+
+func main() {
+	// TODO gh auth login
+	wfmap = make(map[string]*Workflow)
+	data, err := tools.RunCmd(cmd, "workflow", "list")
+	if err != nil {
+		zap.L().Fatal(err.Error())
+	}
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		ss := strings.Split(line, "\t")
+		wf := &Workflow{name: strings.TrimSpace(ss[0]), status: strings.TrimSpace(ss[1]), id: strings.TrimSpace(ss[2])}
+		wfmap[wf.id] = wf
+	}
+
+	for id, wf := range wfmap {
+		wf.passedTests = make(map[string]bool)
+		wf.failedTests = make(map[string]bool)
+		data, err := tools.RunCmd(cmd, "run", "list", "--workflow", id, "--limit", "1")
+		if err != nil {
+			fmt.Println(err.Error())
+		}
+		ss := strings.Split(string(data), "\t")
+		runID := ss[len(ss)-3]
+		wf.lastRunID = runID
+
+		// get job id from run id
+		data, err = tools.RunCmd(cmd, "api", fmt.Sprintf(
+			"https://api.github.com/repos/K8sbykeshed/k8s-service-validator/actions/runs/%v/jobs", runID))
+		if err != nil {
+			fmt.Printf("error to fetch runner's job: %v \n", err)
+		}
+
+		// parse json response
+		opJobID, err := jq.Parse(".jobs.[0].id")
+		if err != nil {
+			fmt.Printf("error to fetch runner's job id: %v \n", err)
+		}
+		lastJobID, err := opJobID.Apply(data)
+		if err != nil {
+			fmt.Printf("error to parse response: %v \n", err)
+		}
+
+		opCompletedTime, err := jq.Parse(".jobs.[0].completed_at")
+		if err != nil {
+			fmt.Printf("error to fetch job's completed time: %v \n", err)
+		}
+		completedTime, err := opCompletedTime.Apply(data)
+		if err != nil {
+			fmt.Printf("error to parse response: %v \n", err)
+		}
+
+		wf.lastJobID = string(lastJobID)
+		wf.lastJobCompletedAt = string(completedTime)
+
+		// retrieve and process job log
+		data, err = tools.RunCmd(cmd, "run", "view", "--job", wf.lastJobID, "--log")
+		if err != nil {
+			fmt.Printf("error to fetch job logs: %v \n", err)
+		}
+		logLines := strings.Split(string(data), "\n")
+		for _, line := range logLines {
+			if index := strings.Index(line, keyPassInLog); index != -1 {
+				l := processLine(line, index)
+				if l != "" {
+					wf.passedTests[l] = true
+				}
+			} else if index := strings.Index(line, keyFailInLog); index != -1 {
+				l := processLine(line, index)
+				if l != "" {
+					wf.failedTests[l] = true
+				}
+			}
+		}
+	}
+
+	// report
+	// currently only in std, can be extendable to more endpoints
+	report := generateReport()
+	fmt.Println(report)
+}
+
+func processLine(l string, index int) string {
+	if len(l) > index+11 {
+		l = l[index+11:]
+		ll := strings.Split(l, "/")
+		if len(ll) == 2 {
+			return ll[1]
+		}
+	}
+	return ""
+}
+
+func generateReport() string {
+	header := "Aggregated testing report from CIs running with various CNIs and proxies:"
+	lines := []string{header}
+	for _, wf := range wfmap {
+		lines = append(lines, "\n======================")
+		wfResult := "FAILED"
+		if len(wf.failedTests) == 0 {
+			wfResult = "PASSED"
+		}
+		lines = append(lines, fmt.Sprintf("[ %v ] - %v", wfResult, wf.name),
+			fmt.Sprintf("* status: %s, action run ID: %s, completed at: %v",
+				wf.status, wf.lastRunID, wf.lastJobCompletedAt))
+
+		if len(wf.passedTests) != 0 {
+			lines = append(lines, "PASSED TESTS:")
+			for t := range wf.passedTests {
+				lines = append(lines, "- "+t)
+			}
+		} else {
+			lines = append(lines, "PASSED TESTS: NONE")
+		}
+
+		if len(wf.failedTests) != 0 {
+			lines = append(lines, "FAILED TESTS:")
+			for t := range wf.failedTests {
+				lines = append(lines, "- "+t)
+			}
+		} else {
+			lines = append(lines, "FAILED TESTS: NONE")
+		}
+	}
+	return strings.Join(lines, "\n")
+}

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -343,6 +343,8 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8 h1:ajJQhvqPSQFJJ4aV5mDAMx8F7iFi6Dxfo6y62wymLNs=
+github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8/go.mod h1:Nw/CCOXNyF5JDd6UpYxBwG5WWZ2FOJ/d5QnXL4KQ6vY=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/tools/helpers.go
+++ b/tools/helpers.go
@@ -1,7 +1,11 @@
 package tools
 
 import (
+	"fmt"
+	"os/exec"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/k8sbykeshed/k8s-service-validator/matrix"
 
@@ -19,4 +23,15 @@ func MustNoWrong(wrongNum int, t *testing.T) {
 	if wrongNum > 0 {
 		t.Errorf("Wrong results number %d", wrongNum)
 	}
+}
+
+func RunCmd(name string, args ...string) ([]byte, error) {
+	cmd := exec.Command(name, args...)
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to run cmd: %v", cmd.String()))
+	}
+
+	return out, nil
 }


### PR DESCRIPTION
Tooling to summarize validation results from different CIs, report is like:
```
$ make report
go run ./cmd/report/main.go
Aggregated testing report from CIs running with various CNIs and proxies:

======================
[ FAILED ] - Kube-Proxy-IPVS-mode
* status: active, action run ID: 1696991564, completed at: "2022-01-14T09:31:17Z"
PASSED TESTS:
- HeadlessLabel (44.29s)
- ClusterIP (7.67s)
- LoadBalancer (123.34s)
- SessionAffinity (37.31s)
- UDP_stale_endpoint (30.28s)
- ProxyNameLabel (44.79s)
- NodePort (22.35s)
- EndlessService (4.78s)
- Hairpin (1.27s)
- NodePort_Traffic_Local (7.12s)
- HostNetwork (11.46s)
FAILED TESTS:
- External_Service (53.87s)

======================
[ PASSED ] - golangci-lint
* status: active, action run ID: 1696991568, completed at: "2022-01-14T09:22:31Z"
PASSED TESTS: NONE
FAILED TESTS: NONE

======================
[ FAILED ] - Calico-eBPF-3.21
* status: active, action run ID: 1696991570, completed at: "2022-01-14T09:36:14Z"
PASSED TESTS:
- NodePort_Traffic_Local (17.39s)
- External_Service (1.32s)
- HostNetwork (11.59s)
- ProxyNameLabel (45.00s)
- ClusterIP (8.33s)
- NodePort (21.99s)
- EndlessService (30.70s)
- Hairpin (0.97s)
- LoadBalancer (122.47s)
- UDP_stale_endpoint (30.23s)
- HeadlessLabel (39.23s)
FAILED TESTS:
- SessionAffinity (35.57s)

======================
[ FAILED ] - Cilium-eBPF-1.11.0
* status: active, action run ID: 1696991572, completed at: "2022-01-14T09:34:34Z"
PASSED TESTS:
- ProxyNameLabel (40.04s)
- HeadlessLabel (39.73s)
- ClusterIP (2.52s)
- LoadBalancer (122.96s)
- EndlessService (30.74s)
- SessionAffinity (29.31s)
- External_Service (1.30s)
- NodePort (22.21s)
- Hairpin (1.11s)
- UDP_stale_endpoint (30.42s)
- HostNetwork (11.44s)
FAILED TESTS:
- NodePort_Traffic_Local (9.10s)

======================
[ FAILED ] - GH-Antrea-Proxy-1.4
* status: active, action run ID: 1696991566, completed at: "2022-01-14T09:32:20Z"
PASSED TESTS:
- NodePort (23.42s)
- LoadBalancer (123.58s)
- Hairpin (1.38s)
- SessionAffinity (32.27s)
- ClusterIP (9.03s)
- NodePort_Traffic_Local (37.32s)
- External_Service (1.86s)
- UDP_stale_endpoint (30.28s)
- HostNetwork (11.84s)
- EndlessService (2.16s)
FAILED TESTS:
- ProxyNameLabel (15.29s)
- HeadlessLabel (14.92s)

======================
[ FAILED ] - kPNG-nftables-backend
* status: active, action run ID: 1696991567, completed at: "2022-01-14T09:33:12Z"
PASSED TESTS:
- NodePort (16.78s)
- LoadBalancer (91.86s)
- EndlessService (3.50s)
- Hairpin (0.63s)
- NodePort_Traffic_Local (26.25s)
- External_Service (0.77s)
- HostNetwork (11.11s)
- ClusterIP (1.44s)
- HeadlessLabel (18.19s)
- ProxyNameLabel (18.49s)
- UDP_stale_endpoint (30.37s)
FAILED TESTS:
- SessionAffinity (32.04s)

======================
[ PASSED ] - kPNG-ipvs-backend
* status: active, action run ID: 1696991569, completed at: "2022-01-14T09:33:46Z"
PASSED TESTS: NONE
FAILED TESTS: NONE

======================
[ PASSED ] - Kube-Proxy-IPTables-1.21-mode
* status: active, action run ID: 1696991565, completed at: "2022-01-14T09:31:31Z"
PASSED TESTS:
- NodePort (22.56s)
- UDP_stale_endpoint (30.22s)
- HostNetwork (11.62s)
- ProxyNameLabel (44.89s)
- ClusterIP (8.59s)
- LoadBalancer (123.15s)
- EndlessService (3.86s)
- Hairpin (1.13s)
- SessionAffinity (40.76s)
- NodePort_Traffic_Local (36.88s)
- External_Service (1.47s)
- HeadlessLabel (45.74s)
FAILED TESTS: NONE

======================
[ PASSED ] - Kube-Proxy-IPTables-1.22-mode
* status: active, action run ID: 1696991571, completed at: "2022-01-14T09:31:41Z"
PASSED TESTS:
- ProxyNameLabel (50.14s)
- NodePort (22.51s)
- LoadBalancer (122.95s)
- Hairpin (1.09s)
- SessionAffinity (39.38s)
- NodePort_Traffic_Local (36.68s)
- External_Service (1.30s)
- HostNetwork (11.49s)
- HeadlessLabel (50.11s)
- ClusterIP (8.13s)
- EndlessService (4.58s)
- UDP_stale_endpoint (30.25s)
FAILED TESTS: NONE

```
