### PR TITLE
Add a test to measure pod-to-pod bandwidth using iperf

### DIFF
--- a/.github/workflows/antrea-proxy.yaml
+++ b/.github/workflows/antrea-proxy.yaml
@@ -35,4 +35,4 @@ jobs:
           ./hack/install_metallb.sh
       - run: |
           go install gotest.tools/gotestsum@latest
-          make summary
+          make summary SUMMARY_OPTIONS="--skip-labels="type=iperf""

--- a/.github/workflows/calico-proxy.yaml
+++ b/.github/workflows/calico-proxy.yaml
@@ -62,4 +62,4 @@ jobs:
           ./hack/install_metallb.sh
       - run: |
           go install gotest.tools/gotestsum@latest
-          make summary
+          make summary SUMMARY_OPTIONS="--skip-labels="type=iperf""

--- a/.github/workflows/cilium-proxy.yaml
+++ b/.github/workflows/cilium-proxy.yaml
@@ -34,4 +34,4 @@ jobs:
           ./hack/install_metallb.sh
       - run: |
           go install gotest.tools/gotestsum@latest
-          make summary
+          make summary SUMMARY_OPTIONS="--skip-labels="type=iperf""

--- a/.github/workflows/kpng-ipvs.yaml
+++ b/.github/workflows/kpng-ipvs.yaml
@@ -27,4 +27,4 @@ jobs:
           ./hack/install_metallb.sh
       - run: |
           go install gotest.tools/gotestsum@latest
-          make summary
+          make summary SUMMARY_OPTIONS="--skip-labels="type=iperf""

--- a/.github/workflows/kpng-nftables.yaml
+++ b/.github/workflows/kpng-nftables.yaml
@@ -27,4 +27,4 @@ jobs:
           ./hack/install_metallb.sh
       - run: |
           go install gotest.tools/gotestsum@latest
-          make summary
+          make summary SUMMARY_OPTIONS="--skip-labels="type=iperf""

--- a/.github/workflows/kube-proxy-iptables-perf.yaml
+++ b/.github/workflows/kube-proxy-iptables-perf.yaml
@@ -1,7 +1,5 @@
-name: Kube-Proxy-IPTables-1.22-mode
+name: Kube-Proxy-IPTables-1.21-mode-perf-testing
 on:
-  # Trigger the workflow on push or pull request,
-  # but only for the main branch
   push:
     branches:
       - main
@@ -15,15 +13,14 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17'
+          go-version: '^1.16'
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.1.0
         with:
           config: hack/kind-multi-worker.yaml
           version: v0.11.0
-          node_image: kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
       - run: |
           ./hack/install_metallb.sh
       - run: |
           go install gotest.tools/gotestsum@latest
-          make summary SUMMARY_OPTIONS="--skip-labels="type=iperf""
+          make summary SUMMARY_OPTIONS="--labels="type=iperf""

--- a/.github/workflows/kube-proxy-iptables.yaml
+++ b/.github/workflows/kube-proxy-iptables.yaml
@@ -23,4 +23,4 @@ jobs:
           ./hack/install_metallb.sh
       - run: |
           go install gotest.tools/gotestsum@latest
-          make summary
+          make summary SUMMARY_OPTIONS="--skip-labels="type=iperf""

--- a/.github/workflows/kube-proxy-ipvs.yaml
+++ b/.github/workflows/kube-proxy-ipvs.yaml
@@ -26,4 +26,4 @@ jobs:
           ./hack/install_metallb.sh
       - run: |
           go install gotest.tools/gotestsum@latest
-          make summary
+          make summary SUMMARY_OPTIONS="--skip-labels="type=iperf""

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,18 @@ TAG?=dev
 ##@ Build
 
 test: ## Runs tests locally
-	go test -v ./tests
+	go test -v ./tests --skip-labels "type=iperf"
+
+test-perf: ## Runs full iperf test and generate bandwidth matrix on all the nodes
+	go test -v ./tests --labels "type=iperf"
 
 unit-test: ## Runs unit test for the service-lb validator
 	go test -v ./entities
+	go test -v ./commands
+	go test -v ./matrix
 
 summary: ## Summarize tests
-	gotestsum --format testname --hide-summary=skipped -- ./tests/...
+	gotestsum --format testname --hide-summary=skipped -- ./tests/... $(SUMMARY_OPTIONS)
 
 build: ## Build tests in a binary
 	go test -v -c -o svc-test ./tests

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 # K8S Service-API Table Tests
 
 [![GH Kube-Proxy - iptables - 1.21](https://github.com/K8sbykeshed/k8s-service-validator/actions/workflows/kube-proxy-iptables.yaml/badge.svg)](https://github.com/K8sbykeshed/k8s-service-validator/actions/workflows/kube-proxy-iptables.yaml)
+[![GH Kube-Proxy - IPTables - 1.21 - Performance Test](https://github.com/K8sbykeshed/k8s-service-validator/actions/workflows/kube-proxy-iptables-perf.yaml/badge.svg)](https://github.com/K8sbykeshed/k8s-service-validator/actions/workflows/kube-proxy-iptables-perf.yaml)
 [![GH Kube-Proxy - IPTables - 1.22](https://github.com/K8sbykeshed/k8s-service-validator/actions/workflows/kube-proxy-iptables-122.yaml/badge.svg)](https://github.com/K8sbykeshed/k8s-service-validator/actions/workflows/kube-proxy-iptables-122.yaml)
 [![GH Kube-Proxy - ipvs](https://github.com/K8sbykeshed/k8s-service-validator/actions/workflows/kube-proxy-ipvs.yaml/badge.svg)](https://github.com/K8sbykeshed/k8s-service-validator/actions/workflows/kube-proxy-ipvs.yaml)
 

--- a/commands/agnhost.go
+++ b/commands/agnhost.go
@@ -1,0 +1,56 @@
+package commands
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+
+	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
+)
+
+// agnCommand represents the server or client agnhost command
+type agnCommand struct{ commandImpl }
+
+// ConnectCommand returns the client command for connecting to the server
+func (c *agnCommand) ConnectCommand() (cmd []string) {
+	switch c.protocol {
+	case v1.ProtocolTCP:
+		cmd = []string{"/agnhost", "connect", net.JoinHostPort(c.addrTo, c.port), "--timeout=5s", "--protocol=tcp"}
+	case v1.ProtocolUDP:
+		cmd = []string{"/agnhost", "connect", net.JoinHostPort(c.addrTo, c.port), "--timeout=5s", "--protocol=udp"}
+	default:
+		zap.L().Error(fmt.Sprintf("protocol %s not supported", c.protocol))
+	}
+	return cmd
+}
+
+// ServeCommand returns server's serve command when binding to a port
+func (c *agnCommand) ServeCommand() (cmd []string) {
+	switch c.protocol {
+	case v1.ProtocolTCP:
+		cmd = []string{"/agnhost", "serve-hostname", "--tcp", "--http=false", "--port", c.port}
+	case v1.ProtocolUDP:
+		cmd = []string{"/agnhost", "serve-hostname", "--udp", "--http=false", "--port", c.port}
+	default:
+		zap.L().Error(fmt.Sprintf("invalid protocol %v", c.protocol))
+	}
+	return cmd
+}
+
+// NewAgnHostClient returns an instance of AgnHost client command
+func NewAgnHostClient(nsFrom, podFrom, containerFrom, addrTo string, port int, protocol v1.Protocol) Client {
+	agnHost := &agnCommand{commandImpl{
+		nsFrom: nsFrom, podFrom: podFrom, containerFrom: containerFrom,
+		addrTo: addrTo, port: strconv.Itoa(port), protocol: protocol,
+	}}
+	agnHost.cmd = agnHost.ConnectCommand()
+	return agnHost
+}
+
+// NewAgnHostServer returns an instance of AgnHost server command
+func NewAgnHostServer(port int, protocol v1.Protocol) Server {
+	agnHost := &agnCommand{commandImpl{port: strconv.Itoa(port), protocol: protocol}}
+	agnHost.cmd = agnHost.ServeCommand()
+	return agnHost
+}

--- a/commands/agnhost_test.go
+++ b/commands/agnhost_test.go
@@ -1,0 +1,38 @@
+package commands
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Agnhost command test", func() {
+	var client Client
+	var server Server
+
+	Context("Agnhost client test", func() {
+		It("render correct connect command", func() {
+			client = NewAgnHostClient("test-ns", "from-pod", "from-container", "192.168.0.2", 8080, v1.ProtocolTCP)
+			Expect(client.ConnectCommand()).To(Equal([]string{"/agnhost", "connect", "192.168.0.2:8080", "--timeout=5s", "--protocol=tcp"}))
+
+			client = NewAgnHostClient("test-ns", "from-pod", "from-container", "192.168.0.2", 8080, v1.ProtocolUDP)
+			Expect(client.ConnectCommand()).To(Equal([]string{"/agnhost", "connect", "192.168.0.2:8080", "--timeout=5s", "--protocol=udp"}))
+
+			client = NewAgnHostClient("test-ns", "from-pod", "from-container", "192.168.0.2", 8080, v1.ProtocolSCTP)
+			Expect(client.ConnectCommand()).To(BeNil())
+		})
+	})
+
+	Context("Agnhost server test", func() {
+		It("render correct serve command", func() {
+			server = NewAgnHostServer(8080, v1.ProtocolTCP)
+			Expect(server.ServeCommand()).To(Equal([]string{"/agnhost", "serve-hostname", "--tcp", "--http=false", "--port", "8080"}))
+
+			server = NewAgnHostServer(8080, v1.ProtocolUDP)
+			Expect(server.ServeCommand()).To(Equal([]string{"/agnhost", "serve-hostname", "--udp", "--http=false", "--port", "8080"}))
+
+			server = NewAgnHostServer(8080, v1.ProtocolSCTP)
+			Expect(server.ServeCommand()).To(BeNil())
+		})
+	})
+})

--- a/commands/commands_suite_test.go
+++ b/commands/commands_suite_test.go
@@ -1,0 +1,13 @@
+package commands
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEntities(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Commands Suite")
+}

--- a/commands/interface.go
+++ b/commands/interface.go
@@ -1,0 +1,60 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	ek "github.com/k8sbykeshed/k8s-service-validator/entities/kubernetes"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// Executor supports Execute function that performs a probe, client method only
+type Executor interface {
+	Execute(config *rest.Config, cs *kubernetes.Clientset) (stdout, stderr string, err error)
+}
+
+// Client defines the methods supported by client-side command
+type Client interface {
+	DebugString() string
+	ConnectCommand() []string
+	Executor
+}
+
+// Server defines the methods supported by server-side command
+type Server interface {
+	ServeCommand() []string
+}
+
+// commandImpl keeps track of configurations of each type of commands
+type commandImpl struct {
+	nsFrom        string
+	podFrom       string
+	containerFrom string
+	addrTo        string
+	port          string
+	protocol      v1.Protocol
+
+	cmd []string
+	Client
+}
+
+// DebugString return the debug string for client connection command
+func (c *commandImpl) DebugString() string {
+	return fmt.Sprintf("kubectl exec %s -c %s -n %s -- %s",
+		c.podFrom, c.containerFrom, c.nsFrom, strings.Join(c.cmd, " "))
+}
+
+func (c *commandImpl) Execute(config *rest.Config, cs *kubernetes.Clientset) (stdout, stderr string, err error) {
+	return ek.ExecWithOptions(config, cs, &ek.ExecOptions{
+		Command:            c.cmd,
+		Namespace:          c.nsFrom,
+		PodName:            c.podFrom,
+		ContainerName:      c.containerFrom,
+		Stdin:              nil,
+		CaptureStdout:      true,
+		CaptureStderr:      true,
+		PreserveWhitespace: false,
+	})
+}

--- a/commands/interface_test.go
+++ b/commands/interface_test.go
@@ -1,0 +1,26 @@
+package commands
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("commandImpl test", func() {
+	Context("get debug string", func() {
+		impl := commandImpl{
+			nsFrom:        "from-ns",
+			podFrom:       "from-pod",
+			containerFrom: "from-container",
+			addrTo:        "192.168.0.2",
+			port:          "8080",
+			protocol:      v1.ProtocolTCP,
+		}
+		impl.cmd = []string{"cmd", "arg1", "arg2"}
+
+		It("prints correct debug string", func() {
+			Expect(impl.DebugString()).To(Equal("kubectl exec from-pod -c from-container -n from-ns -- cmd arg1 arg2"))
+		})
+	})
+})

--- a/commands/iperf.go
+++ b/commands/iperf.go
@@ -1,0 +1,59 @@
+package commands
+
+import (
+	"fmt"
+	"strconv"
+
+	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
+)
+
+// iperfCommand represents the server or client iperf command
+type iperfCommand struct{ commandImpl }
+
+// ConnectCommand returns the client command for connecting to the server
+func (c *iperfCommand) ConnectCommand() (cmd []string) {
+	switch c.protocol {
+	case v1.ProtocolTCP:
+		cmd = []string{"/usr/bin/iperf", "--client", c.addrTo, "--port", c.port, "-yC"}
+	case v1.ProtocolUDP:
+		cmd = []string{"/usr/bin/iperf", "--client", c.addrTo, "--port", c.port, "--udp", "-yC"}
+	case v1.ProtocolSCTP:
+		cmd = []string{"/usr/bin/iperf", "--client", c.addrTo, "--port", c.port, "--sctp", "-yC"}
+	default:
+		zap.L().Error(fmt.Sprintf("protocol %s not supported", c.protocol))
+	}
+	return cmd
+}
+
+// ServeCommand returns server's serve command when binding to a port
+func (c *iperfCommand) ServeCommand() (cmd []string) {
+	switch c.protocol {
+	case v1.ProtocolTCP:
+		cmd = []string{"/usr/bin/iperf", "--server", "--port", c.port}
+	case v1.ProtocolUDP:
+		cmd = []string{"/usr/bin/iperf", "--server", "--port", c.port, "--udp"}
+	case v1.ProtocolSCTP:
+		cmd = []string{"/usr/bin/iperf", "--server", "--port", c.port, "--sctp"}
+	default:
+		zap.L().Error(fmt.Sprintf("protocol %s not supported", c.protocol))
+	}
+	return cmd
+}
+
+// NewIPerfClient returns an instance of iperf client command
+func NewIPerfClient(nsFrom, podFrom, containerFrom, addrTo string, port int, protocol v1.Protocol) Client {
+	iperf := &iperfCommand{commandImpl{
+		nsFrom: nsFrom, podFrom: podFrom, containerFrom: containerFrom,
+		addrTo: addrTo, port: strconv.Itoa(port), protocol: protocol,
+	}}
+	iperf.cmd = iperf.ConnectCommand()
+	return iperf
+}
+
+// NewIPerfServer returns an instance of iperf server command
+func NewIPerfServer(port int, protocol v1.Protocol) Server {
+	iperf := &iperfCommand{commandImpl{port: strconv.Itoa(port), protocol: protocol}}
+	iperf.cmd = iperf.ServeCommand()
+	return iperf
+}

--- a/commands/iperf_test.go
+++ b/commands/iperf_test.go
@@ -1,0 +1,38 @@
+package commands
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("iperf command test", func() {
+	var client Client
+	var server Server
+
+	Context("iperf client test", func() {
+		It("render correct connect command", func() {
+			client = NewIPerfClient("test-ns", "from-pod", "from-container", "192.168.0.2", 8080, v1.ProtocolTCP)
+			Expect(client.ConnectCommand()).To(Equal([]string{"/usr/bin/iperf", "--client", "192.168.0.2", "--port", "8080", "-yC"}))
+
+			client = NewIPerfClient("test-ns", "from-pod", "from-container", "192.168.0.2", 8080, v1.ProtocolUDP)
+			Expect(client.ConnectCommand()).To(Equal([]string{"/usr/bin/iperf", "--client", "192.168.0.2", "--port", "8080", "--udp", "-yC"}))
+
+			client = NewIPerfClient("test-ns", "from-pod", "from-container", "192.168.0.2", 8080, v1.ProtocolSCTP)
+			Expect(client.ConnectCommand()).To(Equal([]string{"/usr/bin/iperf", "--client", "192.168.0.2", "--port", "8080", "--sctp", "-yC"}))
+		})
+	})
+
+	Context("iperf server test", func() {
+		It("render correct serve command", func() {
+			server = NewIPerfServer(8080, v1.ProtocolTCP)
+			Expect(server.ServeCommand()).To(Equal([]string{"/usr/bin/iperf", "--server", "--port", "8080"}))
+
+			server = NewIPerfServer(8080, v1.ProtocolUDP)
+			Expect(server.ServeCommand()).To(Equal([]string{"/usr/bin/iperf", "--server", "--port", "8080", "--udp"}))
+
+			server = NewIPerfServer(8080, v1.ProtocolSCTP)
+			Expect(server.ServeCommand()).To(Equal([]string{"/usr/bin/iperf", "--server", "--port", "8080", "--sctp"}))
+		})
+	})
+})

--- a/commands/netcat.go
+++ b/commands/netcat.go
@@ -1,0 +1,34 @@
+package commands
+
+import (
+	"fmt"
+	"strconv"
+
+	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
+)
+
+// ncCommand represents the client netcat command
+type ncCommand struct{ commandImpl }
+
+func (c *ncCommand) ConnectCommand() (cmd []string) {
+	switch c.protocol {
+	case v1.ProtocolTCP:
+		cmd = []string{"nc", "-w10", c.addrTo, c.port}
+	case v1.ProtocolUDP:
+		cmd = []string{"nc", "-u", "-w10", c.addrTo, c.port}
+	default:
+		zap.L().Error(fmt.Sprintf("protocol %s not supported", c.protocol))
+	}
+	return cmd
+}
+
+// NewNcClient returns an instance of AgnHost client command
+func NewNcClient(nsFrom, podFrom, containerFrom, addrTo string, port int, protocol v1.Protocol) Client {
+	nc := &ncCommand{commandImpl{
+		nsFrom: nsFrom, podFrom: podFrom, containerFrom: containerFrom,
+		addrTo: addrTo, port: strconv.Itoa(port), protocol: protocol,
+	}}
+	nc.cmd = nc.ConnectCommand()
+	return nc
+}

--- a/commands/netcat_test.go
+++ b/commands/netcat_test.go
@@ -1,0 +1,24 @@
+package commands
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Netcat command test", func() {
+	var client Client
+
+	Context("Netcat client test", func() {
+		It("render correct connect command", func() {
+			client = NewNcClient("test-ns", "from-pod", "from-container", "192.168.0.2", 8080, v1.ProtocolTCP)
+			Expect(client.ConnectCommand()).To(Equal([]string{"nc", "-w10", "192.168.0.2", "8080"}))
+
+			client = NewNcClient("test-ns", "from-pod", "from-container", "192.168.0.2", 8080, v1.ProtocolUDP)
+			Expect(client.ConnectCommand()).To(Equal([]string{"nc", "-u", "-w10", "192.168.0.2", "8080"}))
+
+			client = NewNcClient("test-ns", "from-pod", "from-container", "192.168.0.2", 8080, v1.ProtocolSCTP)
+			Expect(client.ConnectCommand()).To(BeNil())
+		})
+	})
+})

--- a/entities/container_test.go
+++ b/entities/container_test.go
@@ -55,10 +55,8 @@ var _ = Describe("container unit test", func() {
 	})
 
 	Context("to k8s spec", func() {
-		BeforeEach(func() {
+		It("should render correct k8s spec with agnhost when image is not specified", func() {
 			container = &Container{Port: 8080, Protocol: v1.ProtocolTCP}
-		})
-		It("should render correct k8s spec", func() {
 			k8sContainer := container.ToK8SSpec()
 			Expect(k8sContainer.Name).To(Equal("cont-8080-tcp"))
 			Expect(k8sContainer.ImagePullPolicy).To(Equal(v1.PullIfNotPresent))

--- a/entities/namespace.go
+++ b/entities/namespace.go
@@ -1,9 +1,12 @@
 package entities
 
 import (
+	"github.com/k8sbykeshed/k8s-service-validator/commands"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const IPerfNamespaceSuffix = "-iperf"
 
 // Namespace defines the structure of namespace
 type Namespace struct {
@@ -24,4 +27,55 @@ func (ns *Namespace) Spec() *v1.Namespace {
 // LabelSelector returns label selector fot the namespace
 func (ns *Namespace) LabelSelector() map[string]string {
 	return map[string]string{"ns": ns.Name}
+}
+
+// NewNamespaceWithPodsGivenImageAndCommand creates a new namespace given a combinations of pod names, ports and protocol
+// also the container image and command are specified
+func NewNamespaceWithPodsGivenImageAndCommand(namespaceName string, podNames []string, ports []int32, protocols []v1.Protocol,
+	image ContainerImage, command []string) *Namespace {
+	pods := make([]*Pod, 0)
+	for _, podName := range podNames {
+		var containers []*Container
+		for _, port := range ports {
+			for _, protocol := range protocols {
+				containers = append(containers, &Container{
+					Port:     port,
+					Protocol: protocol,
+					Image:    image,
+					Command:  command,
+				})
+			}
+		}
+		pods = append(pods, &Pod{Namespace: namespaceName, Name: podName, Containers: containers})
+	}
+	return &Namespace{Name: namespaceName, Pods: pods}
+}
+
+// NewNamespaceWithIPerfPods creates a new namespace given a combinations of pod names, ports and protocol
+// it uses the agnhost image but the iperf serve command
+func NewNamespaceWithIPerfPods(namespaceName string, podNames []string, ports []int32, protocols []v1.Protocol) *Namespace {
+	pods := make([]*Pod, 0)
+	for _, podName := range podNames {
+		var containers []*Container
+		for _, port := range ports {
+			for _, protocol := range protocols {
+				iperf := commands.NewIPerfServer(int(port), protocol)
+				containers = append(containers, &Container{
+					Port:     port,
+					Protocol: protocol,
+					Image:    AgnhostImage,
+					Command:  iperf.ServeCommand(),
+				})
+			}
+		}
+		pods = append(pods, &Pod{Namespace: namespaceName, Name: podName, Containers: containers})
+	}
+	return &Namespace{Name: namespaceName, Pods: pods}
+}
+
+// NewNamespaceWithPods creates a new namespace given a combinations of pod names, ports and protocol
+// without explicitly specifies the container image
+// we use agnhost serve hostname in this case
+func NewNamespaceWithPods(namespaceName string, podNames []string, ports []int32, protocols []v1.Protocol) *Namespace {
+	return NewNamespaceWithPodsGivenImageAndCommand(namespaceName, podNames, ports, protocols, NotSpecifiedImage, []string{})
 }

--- a/matrix/helper.go
+++ b/matrix/helper.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/k8sbykeshed/k8s-service-validator/entities"
+
 	"k8s.io/client-go/util/homedir"
 
 	v1 "k8s.io/api/core/v1"
@@ -21,6 +23,12 @@ import (
 func GetNamespace() string {
 	rand.Seed(time.Now().UnixNano())
 	return fmt.Sprintf("x-%d", rand.Intn(1e5))
+}
+
+// GetIPerfNamespace returns a random namespace starting on x and ends with IPerfNamespaceSuffix
+func GetIPerfNamespace() string {
+	ns := GetNamespace()
+	return ns + entities.IPerfNamespaceSuffix
 }
 
 // NewClientSet returns the Kubernetes clientset
@@ -51,24 +59,31 @@ func NewClientSet() (*kubernetes.Clientset, *rest.Config) {
 
 // ValidateOrFail validates connectivity
 func ValidateOrFail(k8s *KubeManager, model *Model, testCase *TestCase, ignoreLoopback, reachTargetPod bool) int {
+	return ValidateAndMeasureBandwidthOrFail(k8s, model, testCase, ignoreLoopback, reachTargetPod, false)
+}
+
+// ValidateAndMeasureBandwidthOrFail validates connectivity and also measure bandwidth
+// if measureBandWidth is true
+func ValidateAndMeasureBandwidthOrFail(k8s *KubeManager, model *Model, testCase *TestCase, ignoreLoopback,
+	reachTargetPod, measureBandWidth bool) int {
 	var wrong int
 
 	// 1st try
 	zap.L().Info("Validating reachability matrix, first try.")
-	ProbePodToPodConnectivity(k8s, model, testCase, reachTargetPod)
+	ProbePodToPodConnectivity(k8s, model, testCase, reachTargetPod, measureBandWidth)
 
 	// 2nd try, in case first one failed
 	if _, wrong, _, _ = testCase.Reachability.Summary(ignoreLoopback); wrong != 0 {
 		zap.L().Warn("Failed first probe with wrong results, retrying...", zap.Int("wrong", wrong))
-		ProbePodToPodConnectivity(k8s, model, testCase, reachTargetPod)
+		ProbePodToPodConnectivity(k8s, model, testCase, reachTargetPod, measureBandWidth)
 	}
 
 	// at this point we know if we passed or failed, print final matrix and pass/fail the test.
 	if _, wrong, _, _ = testCase.Reachability.Summary(ignoreLoopback); wrong != 0 {
-		testCase.Reachability.PrintSummary(true, true, true)
+		testCase.Reachability.PrintSummary(true, true, true, measureBandWidth)
 		zap.L().Info("Had wrong results in reachability matrix", zap.Int("wrong", wrong))
 	}
-	testCase.Reachability.PrintSummary(true, true, true)
+	testCase.Reachability.PrintSummary(true, true, true, measureBandWidth)
 
 	if wrong == 0 {
 		zap.L().Info("Tests passed, validation succeeded!")

--- a/matrix/matrix_suite_test.go
+++ b/matrix/matrix_suite_test.go
@@ -1,0 +1,13 @@
+package matrix
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMatrix(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Matrix Suite")
+}

--- a/matrix/model.go
+++ b/matrix/model.go
@@ -143,9 +143,11 @@ func (m *Model) AddPod(pod *entities.Pod, namespaceName string) {
 // RemovePod removes pod from the cluster model
 func (m *Model) RemovePod(podName, namespaceName string) error {
 	foundNamespace := false
+	var ns *entities.Namespace
 	for _, n := range m.Namespaces {
 		if n.Name == namespaceName {
 			foundNamespace = true
+			ns = n
 		}
 	}
 
@@ -154,6 +156,11 @@ func (m *Model) RemovePod(podName, namespaceName string) error {
 			if p.Name == podName {
 				*m.pods = append((*m.pods)[:i], (*m.pods)[i+1:]...)
 				return nil
+			}
+		}
+		for i, p := range ns.Pods {
+			if p.Name == podName {
+				ns.Pods = append(ns.Pods[:i], ns.Pods[i+1:]...)
 			}
 		}
 	}

--- a/matrix/model_test.go
+++ b/matrix/model_test.go
@@ -1,0 +1,29 @@
+package matrix
+
+import (
+	"github.com/k8sbykeshed/k8s-service-validator/entities"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("iperf command test", func() {
+	var model *Model
+
+	Context("can create new model", func() {
+		model = NewModel([]string{"ns-1", "ns-2"}, []string{"pod-1", "pod-2"}, []int32{8000, 8001}, []v1.Protocol{v1.ProtocolTCP, v1.ProtocolUDP}, "test.local")
+		Expect(model.Namespaces).To(HaveLen(2))
+		Expect(model.Namespaces[0].Pods).To(HaveLen(2))
+		Expect(model.Namespaces[0].Pods[0].Containers).To(HaveLen(4))
+
+		It("should be able to add a new namespace with iperf pods", func() {
+			model.AddIPerfNamespace("ns-iperf", []string{"pod-iperf"}, []int32{8080}, []v1.Protocol{v1.ProtocolTCP})
+			Expect(model.Namespaces).To(HaveLen(3))
+			iperfNS := model.Namespaces[2]
+			Expect(iperfNS.Pods).To(HaveLen(1))
+			Expect(iperfNS.Pods[0].Containers[0].Image).To(Equal(entities.AgnhostImage))
+			Expect(iperfNS.Pods[0].Containers[0].Command).To(Equal([]string{"/usr/bin/iperf", "--server", "--port", "8080"}))
+		})
+	})
+})

--- a/matrix/reachability.go
+++ b/matrix/reachability.go
@@ -49,7 +49,7 @@ func NewReachability(pods []*entities.Pod, defaultExpectation bool) *Reachabilit
 }
 
 // PrintSummary prints the summary
-func (r *Reachability) PrintSummary(printExpected, printObserved, printComparison bool) {
+func (r *Reachability) PrintSummary(printExpected, printObserved, printComparison, printBandwidth bool) {
 	right, wrong, ignored, comparison := r.Summary(false)
 	if ignored > 0 {
 		zap.L().Warn(fmt.Sprintf("warning: this test doesn't take into consideration hairpin traffic, i.e. traffic whose source and destination is the same pod: %d cases ignored", ignored))
@@ -61,6 +61,9 @@ func (r *Reachability) PrintSummary(printExpected, printObserved, printCompariso
 	}
 	if printObserved {
 		zap.L().Info(fmt.Sprintf("observed:\n\n%s\n\n\n", r.Observed.PrettyPrint("")))
+	}
+	if printBandwidth {
+		zap.L().Info(fmt.Sprintf("observed bandwidth:\n\n%s\n\n\n", r.Observed.PrettyPrintBandwidth("")))
 	}
 	if printComparison {
 		zap.L().Info(fmt.Sprintf("comparison:\n\n%s\n\n\n", comparison.PrettyPrint("")))
@@ -117,6 +120,7 @@ func (r *Reachability) ExpectPeer(from, to *Peer, connected bool) {
 }
 
 // Observe records a single connectivity observation
-func (r *Reachability) Observe(fromPod, toPod entities.PodString, isConnected bool) {
+func (r *Reachability) Observe(fromPod, toPod entities.PodString, isConnected bool, bandwidth *ProbeJobBandwidthResults) {
 	r.Observed.Set(string(fromPod), string(toPod), isConnected)
+	r.Observed.SetBandwidth(string(fromPod), string(toPod), bandwidth)
 }

--- a/matrix/result.go
+++ b/matrix/result.go
@@ -1,0 +1,50 @@
+package matrix
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ProbeJobBandwidthResults models the results of a pod->pod connectivity bandwidth
+type ProbeJobBandwidthResults struct {
+	Bandwidth float64
+}
+
+// FromCommaSeparatedString parses the string output for iperf stdout
+// sample line: 20220207193823,10.244.0.27,59654,10.244.0.27,80,3,0.0-10.0,127987744768,102389776016
+func (r *ProbeJobBandwidthResults) FromCommaSeparatedString(s string) (err error) {
+	splits := strings.Split(s, ",")
+	r.Bandwidth, err = strconv.ParseFloat(splits[8], 32)
+	return err
+}
+
+func prettyString(num float64, unit string) string {
+	if num < 1e3 {
+		return fmt.Sprintf("%f %s/sec", num, unit)
+	} else if num < 1e6 {
+		return fmt.Sprintf("%f K%s/sec", num/1e3, unit)
+	} else if num < 1e9 {
+		return fmt.Sprintf("%f M%s/sec", num/1e6, unit)
+	} else {
+		return fmt.Sprintf("%f G%s/sec", num/1e9, unit)
+	}
+}
+
+// PrettyString prints human-readable string for bandwidth
+func (r *ProbeJobBandwidthResults) PrettyString(inBytes bool) string {
+	if inBytes {
+		return prettyString(r.Bandwidth/8, "Bytes")
+	}
+	return prettyString(r.Bandwidth, "Bits")
+}
+
+// ProbeJobResults packages the model for the results of a pod->pod connectivity probe
+type ProbeJobResults struct {
+	Job         *ProbeJob
+	IsConnected bool
+	Err         error
+	Command     string
+	Endpoint    string
+	Bandwidth   *ProbeJobBandwidthResults // nil if error or bandwidth is not required to measure
+}

--- a/run.sh
+++ b/run.sh
@@ -2,4 +2,4 @@
 
 set -x
 results_dir="${SONOBUOY_RESULTS_DIR:-/tmp/sonobuoy/results}"
-./svc-test | tee "${results_dir}"/out.json
+./svc-test --skip-labels "type=iperf" | tee "${results_dir}"/out.json

--- a/tests/bandwidth_test.go
+++ b/tests/bandwidth_test.go
@@ -1,0 +1,82 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/k8sbykeshed/k8s-service-validator/entities"
+	"github.com/k8sbykeshed/k8s-service-validator/matrix"
+	"github.com/k8sbykeshed/k8s-service-validator/tools"
+	"go.uber.org/zap"
+
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+// 1. Create a new namespace e.g. x-70212-iperf
+// 2. For each node, launch an iperf server pod listening to port 80 (TCP)
+// 3. Probe reachability and measure from pod-A to pod-B
+func TestBandwidth(t *testing.T) {
+	var (
+		iperfPodNames      []string
+		iperfNamespaceName string
+		err                error
+
+		nodes          []*v1.Node
+		pods           []*entities.Pod
+		iperfNamespace *entities.Namespace
+	)
+
+	featureBandwidth := features.New("Bandwidth among nodes").WithLabel("type", "iperf").
+		Setup(func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
+			iperfNamespaceName = matrix.GetIPerfNamespace()
+			if nodes, err = manager.GetReadyNodes(); err != nil {
+				log.Fatal(err)
+			}
+			zap.L().Info("Deploy iperf servers for each node in namespace", zap.String("namespace", namespace))
+
+			// Generate pod names using existing nodes as iperf servers
+			for i := 1; i <= len(nodes); i++ {
+				iperfPodNames = append(iperfPodNames, fmt.Sprintf("pod-%d-iperf", i))
+			}
+			iperfNamespace = model.AddIPerfNamespace(iperfNamespaceName, iperfPodNames, []int32{80}, []v1.Protocol{v1.ProtocolTCP})
+			if err = manager.StartPodsInNamespace(model, nodes, iperfNamespace); err != nil {
+				log.Fatal(err)
+			}
+			// Wait until HTTP servers including iperf are up.
+			if err = manager.WaitForHTTPServers(model); err != nil {
+				log.Fatal(err)
+			}
+			return ctx
+		}).
+		Assess("bandwidth test",
+			func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
+				pods = model.AllIPerfPods()
+				zap.L().Info("Wait and set iPerf pods IP.")
+				for _, pod := range pods {
+					if err = manager.WaitAndSetIPs(pod); err != nil {
+						log.Fatal(err)
+					}
+				}
+				zap.L().Info("Measure bandwidth across nodes.")
+				reachabilityTCP := matrix.NewReachability(pods, true)
+				tools.MustNoWrong(matrix.ValidateAndMeasureBandwidthOrFail(manager, model, &matrix.TestCase{
+					ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: reachabilityTCP, ServiceType: entities.PodIP,
+				}, false, false, true), t)
+				return ctx
+			}).
+		Teardown(
+			func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
+				zap.L().Info("Cleanup iperf namespace.", zap.String("namespace", iperfNamespaceName))
+				if err := manager.DeleteNamespaces([]string{iperfNamespaceName}); err != nil {
+					log.Fatal(err)
+				}
+				return ctx
+			}).
+		Feature()
+
+	testenv.Test(t, featureBandwidth)
+}

--- a/tests/bandwidth_test.go
+++ b/tests/bandwidth_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"github.com/k8sbykeshed/k8s-service-validator/consts"
 	"log"
 	"testing"
 
@@ -36,8 +37,7 @@ func TestBandwidth(t *testing.T) {
 			if nodes, err = manager.GetReadyNodes(); err != nil {
 				log.Fatal(err)
 			}
-			zap.L().Info("Deploy iperf servers for each node in namespace", zap.String("namespace", namespace))
-
+			zap.L().Info("Deploy iperf servers for each node in namespace", zap.String("namespace", iperfNamespaceName))
 			// Generate pod names using existing nodes as iperf servers
 			for i := 1; i <= len(nodes); i++ {
 				iperfPodNames = append(iperfPodNames, fmt.Sprintf("pod-%d-iperf", i))
@@ -45,6 +45,29 @@ func TestBandwidth(t *testing.T) {
 			iperfNamespace = model.AddIPerfNamespace(iperfNamespaceName, iperfPodNames, []int32{80}, []v1.Protocol{v1.ProtocolTCP})
 			if err = manager.StartPodsInNamespace(model, nodes, iperfNamespace); err != nil {
 				log.Fatal(err)
+			}
+			zap.L().Info("Wait and set iPerf pods IP.")
+			pods = model.AllIPerfPods()
+			for _, pod := range pods {
+				if err = manager.WaitAndSetIPs(pod); err != nil {
+					log.Fatal(err)
+				}
+			}
+			if len(manager.PendingPods) > 0 {
+				// Remove pods which are pending because of taints
+				zap.L().Info(fmt.Sprintf("Removing %v iperf pods as stale in pending(likely because of taints).", len(manager.PendingPods)))
+				for pendingPod, pollTimes := range manager.PendingPods {
+					if pollTimes > consts.PollTimesToDeterminePendingPod {
+						err := model.RemovePod(pendingPod, iperfNamespaceName)
+						if err != nil {
+							zap.L().Debug(err.Error())
+						}
+						if err := manager.DeletePod(pendingPod, iperfNamespaceName); err != nil {
+							log.Fatal(err)
+						}
+						delete(manager.PendingPods, pendingPod)
+					}
+				}
 			}
 			// Wait until HTTP servers including iperf are up.
 			if err = manager.WaitForHTTPServers(model); err != nil {
@@ -55,12 +78,7 @@ func TestBandwidth(t *testing.T) {
 		Assess("bandwidth test",
 			func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
 				pods = model.AllIPerfPods()
-				zap.L().Info("Wait and set iPerf pods IP.")
-				for _, pod := range pods {
-					if err = manager.WaitAndSetIPs(pod); err != nil {
-						log.Fatal(err)
-					}
-				}
+
 				zap.L().Info("Measure bandwidth across nodes.")
 				reachabilityTCP := matrix.NewReachability(pods, true)
 				tools.MustNoWrong(matrix.ValidateAndMeasureBandwidthOrFail(manager, model, &matrix.TestCase{

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -99,15 +99,16 @@ func TestMain(m *testing.M) {
 			if len(manager.PendingPods) > 0 {
 				// Remove pods which are pending because of taints
 				zap.L().Info(fmt.Sprintf("Removing %v pods as stale in pending(likely because of taints).", len(manager.PendingPods)))
-				for pendingPods, pollTimes := range manager.PendingPods {
+				for pendingPod, pollTimes := range manager.PendingPods {
 					if pollTimes > consts.PollTimesToDeterminePendingPod {
-						err := model.RemovePod(pendingPods, namespace)
+						err := model.RemovePod(pendingPod, namespace)
 						if err != nil {
 							zap.L().Debug(err.Error())
 						}
-						if err := manager.DeletePod(pendingPods, namespace); err != nil {
+						if err := manager.DeletePod(pendingPod, namespace); err != nil {
 							log.Fatal(err)
 						}
+						delete(manager.PendingPods, pendingPod)
 					}
 				}
 			}


### PR DESCRIPTION
Add `iperf` as one of the available containers / commands, aside from `netcat` and `agnhost`. Probably output some more useful information like latencies / bandwidths than the boolean isConnected.