### PR TITLE
added selector and taints tolerance in pod specs.

### DIFF
--- a/consts/consts.go
+++ b/consts/consts.go
@@ -1,0 +1,3 @@
+package consts
+
+const PollTimesToDeterminePendingPod = 2

--- a/entities/pod.go
+++ b/entities/pod.go
@@ -157,11 +157,13 @@ func (p *Pod) LabelSelector() map[string]string {
 func (p *Pod) ToK8SSpec() *v1.Pod {
 	zero := int64(0)
 	podSpec := v1.PodSpec{
-		NodeSelector:                  map[string]string{"kubernetes.io/hostname": p.NodeName},
 		Containers:                    ContainersToK8SSpec(p.Containers),
 		TerminationGracePeriodSeconds: &zero,
 		HostNetwork:                   p.HostNetwork,
-		Tolerations:                   defaultTolerationsForWindowsNodes(),
+		Tolerations:                   DefaultTolerationsForWindowsNodes(),
+	}
+	if p.NodeName != "" {
+		podSpec.NodeSelector = map[string]string{"kubernetes.io/hostname": p.NodeName}
 	}
 	if p.InitContainers != nil {
 		podSpec.InitContainers = ContainersToK8SSpec(p.InitContainers)
@@ -178,7 +180,7 @@ func (p *Pod) ToK8SSpec() *v1.Pod {
 }
 
 // defaultTolerationsForWindowsNodes returns the toleration setting for each pod, requested specific for windows
-func defaultTolerationsForWindowsNodes() []v1.Toleration {
+func DefaultTolerationsForWindowsNodes() []v1.Toleration {
 	return []v1.Toleration{{Key: "os", Value: "windows", Effect: "NoSchedule"}}
 }
 

--- a/entities/pod.go
+++ b/entities/pod.go
@@ -157,10 +157,11 @@ func (p *Pod) LabelSelector() map[string]string {
 func (p *Pod) ToK8SSpec() *v1.Pod {
 	zero := int64(0)
 	podSpec := v1.PodSpec{
-		NodeName:                      p.NodeName,
+		NodeSelector:                  map[string]string{"kubernetes.io/hostname": p.NodeName},
 		Containers:                    ContainersToK8SSpec(p.Containers),
 		TerminationGracePeriodSeconds: &zero,
 		HostNetwork:                   p.HostNetwork,
+		Tolerations:                   defaultTolerationsForWindowsNodes(),
 	}
 	if p.InitContainers != nil {
 		podSpec.InitContainers = ContainersToK8SSpec(p.InitContainers)
@@ -174,6 +175,11 @@ func (p *Pod) ToK8SSpec() *v1.Pod {
 		},
 		Spec: podSpec,
 	}
+}
+
+// defaultTolerationsForWindowsNodes returns the toleration setting for each pod, requested specific for windows
+func defaultTolerationsForWindowsNodes() []v1.Toleration {
+	return []v1.Toleration{{Key: "os", Value: "windows", Effect: "NoSchedule"}}
 }
 
 // PodString is the representation of the Pod on a string

--- a/tests/basic_service_test.go
+++ b/tests/basic_service_test.go
@@ -79,10 +79,6 @@ func TestBasicService(t *testing.T) { // nolint
 	podsWithAffinity := make([]*entities.Pod, 2)
 	featureSessionAffinity := features.New("SessionAffinity").WithLabel("type", "cluster_ip_sessionAffinity").
 		Setup(func(context.Context, *testing.T, *envconf.Config) context.Context {
-			nodes, err := manager.GetReadyNodes()
-			if err != nil {
-				t.Fatal(err)
-			}
 			services = make(kubernetes.Services, len(pods))
 			// add new label to two pods, pod-3 and pod-4
 			labelKey := "app"
@@ -96,10 +92,9 @@ func TestBasicService(t *testing.T) { // nolint
 						{Port: 80, Protocol: v1.ProtocolTCP},
 						{Port: 81, Protocol: v1.ProtocolTCP},
 					},
-					NodeName: nodes[1].Name,
-					Labels:   map[string]string{labelKey: labelValue},
+					Labels: map[string]string{labelKey: labelValue},
 				}
-				err = manager.InitializePod(newPod)
+				err := manager.InitializePod(newPod)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/tests/hostnetwork_test.go
+++ b/tests/hostnetwork_test.go
@@ -18,11 +18,6 @@ func TestHostNetwork(t *testing.T) {
 	// 2. verify successful connection between pod-5 and all pods in the cluster
 	testHostNetwork := features.New("HostNetwork").WithLabel("type", "hostNetwork").
 		Setup(func(context.Context, *testing.T, *envconf.Config) context.Context {
-			nodes, err := manager.GetReadyNodes()
-			if err != nil {
-				t.Fatal(err)
-			}
-
 			newPod = &entities.Pod{
 				Name:        "pod-5",
 				Namespace:   namespace,
@@ -31,9 +26,8 @@ func TestHostNetwork(t *testing.T) {
 				Containers: []*entities.Container{
 					{Port: 80, Protocol: v1.ProtocolTCP},
 				},
-				NodeName: nodes[0].Name,
 			}
-			err = manager.InitializePod(newPod)
+			err := manager.InitializePod(newPod)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Added taints tolerance to the validator, so that it will not mess with nodes with "NoSchedule" taints in a production cluster.

- pods will get scheduled on nodes evenly
- `NoSchedule` taint works
- added default tolerance for windows nodes' taint:
```taints:
  - effect: NoSchedule
    key: os
    value: windows
```
- Ensure tests will not get blocked by pending pods:
    - Removed pending pods which cannot get spun up on the nodes.
Pods keeps in pending state, may because of cannot find the node to deploy, due to resource constraints in the cluster, or taints without corresponding tolerance.
Need to remove the pods, as this case is non networking related, and blocks the tests.


Snapshots:
Nodes with taint:
![image](https://user-images.githubusercontent.com/3346348/152285861-7b3b9b06-23ca-438d-b9b2-f5fa579209f8.png)

Pods scheduling:
![image](https://user-images.githubusercontent.com/3346348/152285909-658ddbe2-04dd-48ad-a4d0-77196ed8a03a.png)

Control plane will not get nodes scheduled on, as the multiple `NoSchedule` taints; while kind-worker2 has a pod scheduled on, as the taint tolerance.

![image](https://user-images.githubusercontent.com/3346348/152299596-eedc79ac-b503-4eba-8367-21591e942274.png)

![image](https://user-images.githubusercontent.com/3346348/152299603-b554a57d-9e55-436c-b36e-852f99f6336e.png)
