### PR TITLE
Refined service label tests

### DIFF
--- a/.github/workflows/golangci.yaml
+++ b/.github/workflows/golangci.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v2.3.0
         with:
           version: latest
           working-directory: .

--- a/tests/label_test.go
+++ b/tests/label_test.go
@@ -93,8 +93,12 @@ func TestLabels(t *testing.T) { // nolint
 			zap.L().Info("remove label from the toggledService", zap.String("label", labelKey))
 			mustOrFatal(toggledService.RemoveLabel(labelKey), t)
 
-			toPod.SetClusterIP(toggledService.GetClusterIP())
 			zap.L().Info("verify the toggledService is up again without", zap.String("label", labelKey))
+			clusterIP, err := toggledService.WaitForClusterIP()
+			if err != nil {
+				t.Fatal(err)
+			}
+			toPod.SetClusterIP(clusterIP)
 			tools.MustNoWrong(matrix.ValidateOrFail(manager, model, &matrix.TestCase{
 				ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: upReachability,
 				ServiceType: entities.ClusterIP,

--- a/tests/label_test.go
+++ b/tests/label_test.go
@@ -42,10 +42,8 @@ func TestLabels(t *testing.T) { // nolint
 	downReachability := matrix.NewReachability(pods, true)
 	downReachability.ExpectPeer(&matrix.Peer{Namespace: namespace}, &matrix.Peer{Namespace: namespace, Pod: toPod.Name}, false)
 
-	getSetupFunc := func(labelKey, labelValue string) features.Func {
+	getSetupFunc := func() features.Func {
 		return func(_ context.Context, t *testing.T, _ *envconf.Config) context.Context {
-			var err error
-
 			// create a service without the label, but will be toggled later
 			toggledService = kubernetes.NewService(manager.GetClientSet(), toPod.ClusterIPService())
 			if _, err := toggledService.Create(); err != nil {
@@ -106,12 +104,12 @@ func TestLabels(t *testing.T) { // nolint
 	}
 
 	featureProxyNameLabel := features.New("ProxyNameLabel").WithLabel("type", "ProxyNameLabel").
-		Setup(getSetupFunc(proxyNameLabelKey, proxyNameLabelValue)).Teardown(teardown).
+		Setup(getSetupFunc()).Teardown(teardown).
 		Assess("should implement service.kubernetes.io/service-proxy-name",
 			getAssessFunc(proxyNameLabelKey, proxyNameLabelValue)).Feature()
 
 	featureHeadlessLabel := features.New("HeadlessLabel").WithLabel("type", "HeadlessLabel").
-		Setup(getSetupFunc(headlessLabelKey, proxyNameLabelValue)).Teardown(teardown).
+		Setup(getSetupFunc()).Teardown(teardown).
 		Assess("should implement service.kubernetes.io/headless",
 			getAssessFunc(headlessLabelKey, headlessLabelValue)).Feature()
 


### PR DESCRIPTION
Make sure to update cluster IP as endpoint, whenever label is added and removed;
Removed the additional control group, as tests are already sufficient.
